### PR TITLE
Bug fixing and refactor

### DIFF
--- a/src/main/scala/actor_ia/MoveGenerator.scala
+++ b/src/main/scala/actor_ia/MoveGenerator.scala
@@ -1,6 +1,7 @@
 package actor_ia
 
-import model.{GameSnapshot, GameVariant, Piece, Player}
+import model.GameSnapshot.GameSnapshotImpl
+import model.{GameSnapshot, GameVariant, ParserProlog, ParserPrologImpl, Piece, Player, TheoryGame}
 import utils.BoardGame.BoardCell
 import utils.{Coordinate, Move}
 
@@ -105,7 +106,7 @@ object MoveGenerator {
       (adjacentCells(1).nonEmpty &&
         adjacentCells(3).nonEmpty &&
         kingCapturedInLine(adjacentCells(1).head, adjacentCells(3).head)) ||
-        (adjacentCells(0).nonEmpty &&
+        (adjacentCells.head.nonEmpty &&
           adjacentCells(2).nonEmpty &&
           kingCapturedInLine(adjacentCells.head.head, adjacentCells(2).head))
 
@@ -126,7 +127,7 @@ object MoveGenerator {
     kingCoord.equals(gameSnapshot.getBoard.specialCoordinates.last)
 
   def kingNextToThrone(gameSnapshot: GameSnapshot, kingCoord: Coordinate): Boolean =
-    gameSnapshot.getBoard.orthogonalCells(gameSnapshot.getBoard.centerCoordinates).map(_.head).contains(kingCoord)
+    gameSnapshot.getBoard.orthogonalCells(gameSnapshot.getBoard.centerCoordinates).map(_.head.getCoordinate).contains(kingCoord)
 
   private def isOwner(pawn: Piece.Value, player: Player.Value): Boolean = (pawn, player) match {
     case (Piece.WhitePawn, Player.White) => true

--- a/src/main/scala/actor_ia/RootActor.scala
+++ b/src/main/scala/actor_ia/RootActor.scala
@@ -21,6 +21,6 @@ object RootActor {
 
   }
 
-  def rootUpdateBestMove(hashMapSonRef: mutable.HashMap[ActorRef, Move], sonRef: ActorRef): Option[Move] = 
+  def rootUpdateBestMove(hashMapSonRef: mutable.HashMap[ActorRef, Move], sonRef: ActorRef): Option[Move] =
     Option(hashMapSonRef(sonRef))
 }

--- a/src/main/scala/ia/EvaluationFunction.scala
+++ b/src/main/scala/ia/EvaluationFunction.scala
@@ -36,7 +36,8 @@ object EvaluationFunction {
       board = gameSnapshot.getBoard
       boardSize = board.size
       kingCoord = findKing(board.rows)
-      kingOrthogonalCells = board.orthogonalCells(kingCoord)
+      //TODO utilizzare mappa(OrthogonalDirection, List) (togliere .values.toList)
+      kingOrthogonalCells = board.orthogonalCells(kingCoord).values.toList
       kingAdjacentCells = kingOrthogonalCells.map(_.take(1)).map(l => if(l.nonEmpty) Option(l.head) else Option.empty)
       cornerCoordinates = board.cornerCoordinates
       centralCoordinate = board.centerCoordinates

--- a/src/main/scala/model/gameRules.pl
+++ b/src/main/scala/model/gameRules.pl
@@ -534,8 +534,7 @@ kingOnThrone(S, C) :- centralCellCoord(S, C).
 %%% Returns if the king is on a cell next to the throne (central cell).
 % [kingNextToThrone(+BoardSize, +KingCoordinate)]
 kingNextToThrone(S, C) :-
-		nextToCentralCellCoords(S, [U, R, D, L]),
-		append4(U, R, D, L, Around),
+		nextToCentralCellCoords(S, Around),
 		member(C, Around).
 
 %%% Returns king's adjacent cells divided in Horizontal and Vertical (one cell per side).
@@ -1042,6 +1041,20 @@ testBoard7KingNextToThroneCaptured3Sides :-
 		makeMove(G1, p(4, 4), p(4, 3), _, G2),
 		makeMove(G2, p(2, 4), p(5, 3), _, O),
 		gameWinner(O, b).
+
+% yes
+testBoard7KingNextToThroneNotCaptured2Sides :-
+		newGame(brandubh, G),
+		makeMove(G, p(4, 6), p(1, 6), _, G1),
+		makeMove(G1, p(4, 5), p(7, 5), _, G2),
+		makeMove(G2, p(6, 4), p(6, 5), _, G3),
+		makeMove(G3, p(4, 4), p(4, 5), _, G4),
+		makeMove(G4, p(2, 4), p(2, 5), _, G5),
+		makeMove(G5, p(7, 5), p(7, 6), _, G6),
+		makeMove(G6, p(2, 5), p(3, 5), _, G7),
+		makeMove(G7, p(7, 6), p(7, 5), _, G8),
+		makeMove(G8, p(6, 5), p(5, 5), _, G9),
+		gameWinner(G9, n).
 
 % yes
 testBoard7Draw :-

--- a/src/main/scala/utils/BoardGame.scala
+++ b/src/main/scala/utils/BoardGame.scala
@@ -1,6 +1,9 @@
 package utils
 
 import model.Piece
+import utils.BoardGame.OrthogonalDirection.OrthogonalDirection
+
+import scala.collection.immutable.HashMap
 
 /**
  * Util class representing a 2D coordinate
@@ -65,6 +68,11 @@ object BoardGame {
 
   }
 
+  object OrthogonalDirection extends Enumeration {
+    type OrthogonalDirection = Value
+    val Up, Right, Down, Left = Value
+  }
+
   trait Board {
     /**
      * Defines board's cells list.
@@ -85,7 +93,7 @@ object BoardGame {
 
     def toString: String
 
-    def orthogonalCells(coordinate: Coordinate): List[List[BoardCell]]
+    def orthogonalCells(coordinate: Coordinate): Map[OrthogonalDirection, List[BoardCell]]
 
     def specialCoordinates: List[Coordinate]
 
@@ -116,8 +124,11 @@ object BoardGame {
 
       override def toString: String = rows.map(_.mkString("[", ",", "]")).mkString("[", ",", "]")
 
-      override def orthogonalCells(coordinate: Coordinate): List[List[BoardCell]] =
-        List(upCells(coordinate), rightCells(coordinate), downCells(coordinate), leftCells(coordinate))
+      override def orthogonalCells(coordinate: Coordinate): Map[OrthogonalDirection, List[BoardCell]] =
+        HashMap(OrthogonalDirection.Up -> upCells(coordinate),
+          OrthogonalDirection.Right -> rightCells(coordinate),
+          OrthogonalDirection.Down -> downCells(coordinate),
+          OrthogonalDirection.Left -> leftCells(coordinate))
 
       private def upCells(coordinate: Coordinate): List[BoardCell] =
         (coordinate.x - 1 to 1 by -1).toList.map(Coordinate(_, coordinate.y)).map(getCell)
@@ -136,7 +147,7 @@ object BoardGame {
 
       override def cornerCoordinates: List[Coordinate] =
         List(Coordinate(1, 1), Coordinate(1, size), Coordinate(size, 1),
-        Coordinate(size, size))
+          Coordinate(size, size))
 
       override def centerCoordinates: Coordinate = Coordinate(size / 2 + 1, size / 2 + 1)
 

--- a/src/test/scala/MakingMovesTests.scala
+++ b/src/test/scala/MakingMovesTests.scala
@@ -108,6 +108,11 @@ class MakingMovesTests extends FunSuite {
     assert(goal.isSuccess)
   }
 
+  test("Tests if in 7x7 board black doesn't win capturing the king on two sides plus hostile throne.") {
+    goal = prolog.solve("testBoard7KingNextToThroneNotCaptured2Sides.")
+    assert(goal.isSuccess)
+  }
+
   test("Tests a draw scenario.") {
     goal = prolog.solve("testBoard7Draw.")
     assert(goal.isSuccess)

--- a/src/test/scala/MoveGeneratorTest.scala
+++ b/src/test/scala/MoveGeneratorTest.scala
@@ -15,15 +15,15 @@ class MoveGeneratorTest  extends FunSuite with MockFactory with Matchers {
   var variantTablut:GameVariant.Val = GameVariant.Tablut
   var variantTawlbwrdd:GameVariant.Val = GameVariant.Tawlbwrdd
 
-  var gameBrandubh: (Player.Val, Player.Val, BoardGame.Board, Int) = parserProlog.createGame(variantBrandubh.toString().toLowerCase)
-  var gameHnefatafl: (Player.Val, Player.Val, BoardGame.Board, Int) = parserProlog.createGame(variantHnefatafl.toString().toLowerCase)
-  var gameTablut: (Player.Val, Player.Val, BoardGame.Board, Int) = parserProlog.createGame(variantTablut.toString().toLowerCase)
-  var gameTawlbwrdd: (Player.Val, Player.Val, BoardGame.Board, Int) = parserProlog.createGame(variantTawlbwrdd.toString().toLowerCase)
+  var gameBrandubh: (Player.Val, Player.Val, BoardGame.Board, Int) = _
+  var gameHnefatafl: (Player.Val, Player.Val, BoardGame.Board, Int) = _
+  var gameTablut: (Player.Val, Player.Val, BoardGame.Board, Int) = _
+  var gameTawlbwrdd: (Player.Val, Player.Val, BoardGame.Board, Int) = _
 
-  var snapBrandubh: GameSnapshotImpl = GameSnapshotImpl(variantBrandubh, gameBrandubh._1, gameBrandubh._2, gameBrandubh._3, Option.empty, 0, 0)
-  var snapHnefatafl: GameSnapshotImpl = GameSnapshotImpl(variantHnefatafl, gameHnefatafl._1, gameHnefatafl._2, gameHnefatafl._3, Option.empty, 0, 0)
-  var snapTablut: GameSnapshotImpl = GameSnapshotImpl(variantTablut, gameTablut._1, gameTablut._2, gameTablut._3, Option.empty, 0, 0)
-  var snapTawlbwrdd: GameSnapshotImpl = GameSnapshotImpl(variantTawlbwrdd, gameTawlbwrdd._1, gameTawlbwrdd._2, gameTawlbwrdd._3, Option.empty, 0, 0)
+  var snapBrandubh: GameSnapshotImpl = _
+  var snapHnefatafl: GameSnapshotImpl = _
+  var snapTablut: GameSnapshotImpl = _
+  var snapTawlbwrdd: GameSnapshotImpl = _
 
   test("Test number of possible moves - Brandubh."){
     gameBrandubh = parserProlog.createGame(variantBrandubh.toString().toLowerCase)
@@ -271,8 +271,6 @@ class MoveGeneratorTest  extends FunSuite with MockFactory with Matchers {
 
   }
 
-  //TODO jumped testBoard11KingFarFromThroneCapture
-
   test("Test board 9 king on throne capture - Tablut"){
     gameTablut = parserProlog.createGame(variantTablut.toString().toLowerCase)
     snapTablut = GameSnapshotImpl(variantTablut, gameTablut._1, gameTablut._2, gameTablut._3, Option.empty, 0, 0)
@@ -384,6 +382,23 @@ class MoveGeneratorTest  extends FunSuite with MockFactory with Matchers {
 
   }
 
+  test("Test king not captured on 2 sides next to throne in Brandubh") {
+    gameBrandubh = parserProlog.createGame(variantBrandubh.toString().toLowerCase)
+    snapBrandubh = GameSnapshotImpl(variantBrandubh, gameBrandubh._1, gameBrandubh._2, gameBrandubh._3, Option.empty, 0, 0)
+
+    val step1 = MoveGenerator.makeMove(snapBrandubh, Move(Coordinate(4,6), Coordinate(1,6)))
+    val step2 = MoveGenerator.makeMove(step1, Move(Coordinate(4,5), Coordinate(7,5)))
+    val step3 = MoveGenerator.makeMove(step2, Move(Coordinate(6,4), Coordinate(6,5)))
+    val step4 = MoveGenerator.makeMove(step3, Move(Coordinate(4,4), Coordinate(4,5)))
+    val step5 = MoveGenerator.makeMove(step4, Move(Coordinate(2,4), Coordinate(2,5)))
+    val step6 = MoveGenerator.makeMove(step5, Move(Coordinate(7,5), Coordinate(7,6)))
+    val step7 = MoveGenerator.makeMove(step6, Move(Coordinate(2,5), Coordinate(3,5)))
+    val step8 = MoveGenerator.makeMove(step7, Move(Coordinate(7,6), Coordinate(7,5)))
+    val step9 = MoveGenerator.makeMove(step8, Move(Coordinate(6,5), Coordinate(5,5)))
+
+    assert(step9.getWinner.equals(Player.None))
+  }
+
   test("Test board 7 Draw - Brandubh"){
     gameBrandubh = parserProlog.createGame(variantBrandubh.toString().toLowerCase)
     snapBrandubh = GameSnapshotImpl(variantBrandubh, gameBrandubh._1, gameBrandubh._2, gameBrandubh._3, Option.empty, 0, 0)
@@ -410,18 +425,4 @@ class MoveGeneratorTest  extends FunSuite with MockFactory with Matchers {
 
   }
 
-  //TODO DELETE
-  test("Copy Snapshot - Brandubh") {
-    gameBrandubh = parserProlog.createGame(variantBrandubh.toString().toLowerCase)
-    snapBrandubh = GameSnapshotImpl(variantBrandubh, gameBrandubh._1, gameBrandubh._2, gameBrandubh._3, Option.empty, 0, 0)
-
-    val snapBrandubh2 = snapBrandubh.getCopy
-
-    val step1 = MoveGenerator.makeMove(snapBrandubh2, Move(Coordinate(4,6), Coordinate(1,6)))
-
-    println(snapBrandubh2.getBoard)
-    println()
-    println(snapBrandubh.getBoard)
-    assert(!snapBrandubh2.getBoard.equals(snapBrandubh.getBoard))
-  }
 }

--- a/src/test/scala/ParserTests.scala
+++ b/src/test/scala/ParserTests.scala
@@ -131,6 +131,22 @@ class ParserTests extends FunSuite with MockFactory with Matchers {
     currentGame._2 shouldBe Player.Black
   }
 
+  test("Tests king not captured on 2 sides next two thrones in Brandubh") {
+    inSequence {
+      parser.createGame(GameVariant.Brandubh.toString().toLowerCase())
+      parser.makeLegitMove(Move(Coordinate(4,6), Coordinate(1,6)))
+      parser.makeLegitMove(Move(Coordinate(4,5), Coordinate(7,5)))
+      parser.makeLegitMove(Move(Coordinate(6,4), Coordinate(6,5)))
+      parser.makeLegitMove(Move(Coordinate(4,4), Coordinate(4,5)))
+      parser.makeLegitMove(Move(Coordinate(2,4), Coordinate(2,5)))
+      parser.makeLegitMove(Move(Coordinate(7,5), Coordinate(7,6)))
+      parser.makeLegitMove(Move(Coordinate(2,5), Coordinate(3,5)))
+      parser.makeLegitMove(Move(Coordinate(7,6), Coordinate(7,5)))
+    }
+    val currentGame: (_, Player.Value, _, _) = parser.makeLegitMove(Move(Coordinate(6,5), Coordinate(5,5)))
+    currentGame._2 shouldBe Player.None
+  }
+
   test("Tests draw in Brandubh.") {
     inSequence {
       parser.createGame(GameVariant.Brandubh.toString().toLowerCase())
@@ -153,8 +169,6 @@ class ParserTests extends FunSuite with MockFactory with Matchers {
     }
     val currentGame: (_, Player.Value, _, _) = parser.makeLegitMove(Move(Coordinate(5,6), Coordinate(4,6)))
     currentGame._2 shouldBe Player.Draw
-
-
   }
 
   test("Tests 1 deep clone."){

--- a/src/test/scala/ParserTests.scala
+++ b/src/test/scala/ParserTests.scala
@@ -131,7 +131,7 @@ class ParserTests extends FunSuite with MockFactory with Matchers {
     currentGame._2 shouldBe Player.Black
   }
 
-  test("Tests king not captured on 2 sides next two thrones in Brandubh") {
+  test("Tests king not captured on 2 sides next to throne in Brandubh") {
     inSequence {
       parser.createGame(GameVariant.Brandubh.toString().toLowerCase())
       parser.makeLegitMove(Move(Coordinate(4,6), Coordinate(1,6)))


### PR DESCRIPTION
- Fixed king adjacent to throne capture bug in small boards in prolog: 
     > king used to be captured by two sides instead of three in some cases
- Fixed king adjacent to throne capture bug in small boards in move generator
- Scala orthogonal cells refactor as a map with direction enum and list (still to be correctly used in evaluation function)
