### PR TITLE
Jar build fixed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "PPS_VikingChess"
 
-version := "0.1"
+version := "1.0"
 
 scalaVersion := "2.12.5"
 
@@ -16,9 +16,11 @@ lazy val root = (project in file("."))
       "org.scalacheck" %% "scalacheck" % "1.14.0" % Test,
       "it.unibo.alice.tuprolog" % "tuprolog" % "3.1" ,
       "com.typesafe.akka" %% "akka-actor" % "2.6.6",
-      "org.scala-lang.modules" %% "scala-async" % "0.10.0"
-
+      "org.scala-lang.modules" %% "scala-async" % "0.10.0",
+      "commons-io" % "commons-io" % "2.6"
     ),
+    mainClass := Some("HnefataflApp"),
     crossPaths := false,
-    Test / parallelExecution := false
+    Test / parallelExecution := false,
+    test in assembly := {}
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
+resolvers += Resolver.url("bintray-sbt-plugins", url("http://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)

--- a/src/main/scala/model/prolog/GameRules.scala
+++ b/src/main/scala/model/prolog/GameRules.scala
@@ -1,0 +1,15 @@
+package model.prolog
+import org.apache.commons.io.IOUtils
+import java.io.StringWriter
+
+object GameRules {
+
+  val THEORY: String = "/prolog/gameRules.pl"
+
+  def theory(): String = {
+    val writer = new StringWriter
+    IOUtils.copy(getClass.getResourceAsStream(THEORY), writer, "utf8")
+    writer.toString
+  }
+
+}

--- a/src/main/scala/model/prolog/ParserProlog.scala
+++ b/src/main/scala/model/prolog/ParserProlog.scala
@@ -103,8 +103,6 @@ object ParserProlog extends ParserPrologTrait {
 
   import ImplicitParser._
 
-  val THEORY: String = "/prolog/gameRules.pl"
-
   private val engine: Prolog = new Prolog()
   private var goal: SolveInfo = _
   private var list: Term = new Struct()
@@ -126,7 +124,7 @@ object ParserProlog extends ParserPrologTrait {
     val UndoMove: Value = Value("undoMove")
   }
 
-  engine.setTheory(new Theory(getClass.getResourceAsStream(ParserProlog.THEORY)))
+  engine.setTheory(new Theory(GameRules.theory()))
 
   /**
    * @inheritdoc

--- a/src/test/scala/BoardTest.scala
+++ b/src/test/scala/BoardTest.scala
@@ -1,7 +1,7 @@
 import java.io.FileInputStream
 
 import alice.tuprolog.{Prolog, SolveInfo, Theory}
-import model.prolog.ParserProlog
+import model.prolog.GameRules
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -9,7 +9,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class BoardTest extends FunSuite {
   val prolog: Prolog = new Prolog()
-  val theory: Theory = new Theory(getClass.getResourceAsStream(ParserProlog.THEORY))
+  val theory: Theory = new Theory(GameRules.theory())
   var goal: SolveInfo = _
   prolog.setTheory(theory)
 

--- a/src/test/scala/MakingMovesTest.scala
+++ b/src/test/scala/MakingMovesTest.scala
@@ -1,7 +1,7 @@
 import java.io.FileInputStream
 
 import alice.tuprolog.{Prolog, SolveInfo, Theory}
-import model.prolog.ParserProlog
+import model.prolog.{GameRules, ParserProlog}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -9,7 +9,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class MakingMovesTest extends FunSuite {
   val prolog: Prolog = new Prolog()
-  val theory: Theory = new Theory(getClass.getResourceAsStream(ParserProlog.THEORY))
+  val theory: Theory = new Theory(GameRules.theory())
   var goal: SolveInfo = _
   prolog.setTheory(theory)
 

--- a/src/test/scala/PossibleMovesTest.scala
+++ b/src/test/scala/PossibleMovesTest.scala
@@ -1,7 +1,7 @@
 import java.io.FileInputStream
 
 import alice.tuprolog.{Prolog, SolveInfo, Theory}
-import model.prolog.ParserProlog
+import model.prolog.{GameRules, ParserProlog}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -9,7 +9,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class PossibleMovesTest extends FunSuite {
   val prolog: Prolog = new Prolog()
-  val theory: Theory = new Theory(getClass.getResourceAsStream(ParserProlog.THEORY))
+  val theory: Theory = new Theory(GameRules.theory())
   var goal: SolveInfo = _
   prolog.setTheory(theory)
 

--- a/src/test/scala/UtilsListTest.scala
+++ b/src/test/scala/UtilsListTest.scala
@@ -1,7 +1,7 @@
 import java.io.FileInputStream
 
 import alice.tuprolog.{Prolog, SolveInfo, Theory}
-import model.prolog.ParserProlog
+import model.prolog.{GameRules, ParserProlog}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -9,7 +9,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class UtilsListTest extends FunSuite {
   val prolog: Prolog = new Prolog()
-  val theory: Theory = new Theory(getClass.getResourceAsStream(ParserProlog.THEORY))
+  val theory: Theory = new Theory(GameRules.theory())
   var goal: SolveInfo = _
   prolog.setTheory(theory)
 


### PR DESCRIPTION
- New object GameRules.scala now loads prolog rules and converts them to string for prolog parsing
- Added sbt-assembly plugin for jar building skipping tests